### PR TITLE
Don't log per default

### DIFF
--- a/src/yang/ietf-access-control-list.yang
+++ b/src/yang/ietf-access-control-list.yang
@@ -391,6 +391,7 @@ module ietf-access-control-list {
             }
             leaf logging {
               type boolean;
+              default false;
               description
                 "Log the rule on which the match occured.";
             }


### PR DESCRIPTION
Not sure if I need to motivate or not but I simply don't think it makes sense to log by default.

Fixes #14 