### PR TITLE
Rename features and identities

### DIFF
--- a/src/yang/ietf-access-control-list.yang
+++ b/src/yang/ietf-access-control-list.yang
@@ -67,71 +67,72 @@ module ietf-access-control-list {
   identity ipv4-acl {
     base acl:acl-base;
     description
-       "ACL that primarily matches on fields from the IPv4 header
-       (e.g. IPv4 destination address) and layer 4 headers (e.g. TCP
-       destination port).  An acl of type ipv4-acl does not contain
-       matches on fields in the ethernet header or the IPv6 header.";
+       "ACL that can match on fields from the IPv4 header (e.g. IPv4
+       destination address) and layer 4 headers (e.g. TCP destination
+       port). Matching on L2 headers or L3 headers other than IPv4 is
+       not possible.";
   }
 
   identity ipv6-acl {
     base acl:acl-base;
     description
-      "ACL that primarily matches on fields from the IPv6 header
-      (e.g. IPv6 destination address) and layer 4 headers (e.g. TCP
-      destination port). An acl of type ipv6-acl does not contain
-      matches on fields in the ethernet header or the IPv4 header.";
+      "ACL that can match on fields from the IPv6 header (e.g. IPv6
+      destination address) and layer 4 headers (e.g. TCP destination
+      port). Matching on L2 headers or L3 headers other than IPv6 is not
+      possible.";
+  }
+
+  identity ipv46-acl {
+    base acl:acl-base;
+    description
+      "ACL that can match on fields from an IPv4 or IPv6 header (e.g.
+      IPv4 destination address or IPv6 destination address) and layer 4
+      headers (e.g. TCP destination port). Matching on L2 headers or L3
+      headers other than IPv4 or IPv6 is not possible.";
   }
 
   identity eth-acl {
     base acl:acl-base;
     description
-      "ACL that primarily matches on fields in the ethernet header,
-      like 10/100/1000baseT or WiFi Access Control List. An acl of
-      type eth-acl does not contain matches on fields in the IPv4
-      header, IPv6 header or layer 4 headers.";
+      "ACL that can match on fields in the Ethernet header. Matching on
+      L3 or L4 headers is not possible.";
   }
 
-  identity mixed-l2-l3-ipv4-acl {
+  identity eth-ipv4-acl {
     base "acl:acl-base";
      
     description 
-      "ACL that contains a mix of entries that
-       primarily match on fields in ethernet headers,
-       entries that primarly match on IPv4 headers.
-       Matching on layer 4 header fields may also exist in the
-       list.";
+      "ACL that can match on fields in the Ethernet header, IPv4 header
+      and in L4 headers. Matching on L2 headers other than Ethernet
+      or matching on L3 headers other than IPv4 is not possible.";
   }
 
-  identity mixed-l2-l3-ipv6-acl {
+  identity eth-ipv6-acl {
     base "acl:acl-base";
      
     description 
-      "ACL that contains a mix of entries that
-       primarily match on fields in ethernet headers, entries
-       that primarily match on fields in IPv6 headers. Matching on
-       layer 4 header fields may also exist in the list.";
+      "ACL that can match on fields in the Ethernet header, IPv6 header
+      and in L4 headers. Matching on L2 headers other than Ethernet
+      or matching on L3 headers other than IPv6 is not possible.";
   }
 
-  identity mixed-l2-l3-ipv4-ipv6-acl {
+  identity eth-ipv46-acl {
     base "acl:acl-base";
      
     description 
-      "ACL that contains a mix of entries that
-       primarily match on fields in ethernet headers, entries
-       that primarily match on fields in IPv4 headers, and entries
-       that primarily match on fields in IPv6 headers. Matching on
-       layer 4 header fields may also exist in the list.";
+      "ACL that can match on fields in the Ethernet header, from an IPv4
+      or IPv6 header and layer 4 headers.";
   }
   
-  identity tcp-acl {
+  identity tcp-fields {
     base "acl:acl-base";
   }
   
-  identity udp-acl {
+  identity udp-fields {
     base "acl:acl-base";
   }
   
-  identity icmp-acl {
+  identity icmp-fields {
     base "acl:acl-base";
   }
   
@@ -145,49 +146,54 @@ module ietf-access-control-list {
   /*
    * Features
    */
-   feature l2-acl {
+   feature eth-acl {
      description
-       "Layer 2 ACL supported";
+       "ACL matching on Layer 2 Ethernet supported";
    }
 
    feature ipv4-acl {
      description 
-       "Layer 3 IPv4 ACL supported";
+       "ACL matching on Layer 3 IPv4 supported";
    }
 	
    feature ipv6-acl {
      description
-       "Layer 3 IPv6 ACL supported";
+       "ACL matching on Layer 3 IPv6 supported";
+   }
+
+   feature ipv46-acl {
+     description
+       "ACL matching on Layer 3 IPv4 and IPv6 supported";
    }
 	
-   feature mixed-ipv4-acl {
+   feature eth-ipv4-acl {
      description
-       "Layer 2 and Layer 3 IPv4 ACL supported";
+       "ACL matching on Layer 2 Ethernet and Layer 3 IPv4 supported";
    }
 	
-   feature mixed-ipv6-acl {
+   feature eth-ipv6-acl {
      description
-       "Layer 2 and Layer 3 IPv6 ACL supported";
+       "ACL matching on Layer 2 Ethernet and Layer 3 IPv6 supported";
    }
 	
-   feature l2-l3-ipv4-ipv6-acl {
+   feature eth-ipv46-acl {
      description
-       "Layer 2 and any Layer 3 ACL supported.";
+       "ACL matching on Layer 2 Ethernet and Layer 3 IPv4 and IPv6 supported";
    }
    
-   feature tcp-acl {
+   feature tcp-fields {
      description
-       "TCP header ACL supported.";
+       "TCP header matching supported.";
    }
    
-   feature udp-acl {
+   feature udp-fields {
      description
-       "UDP header ACL supported.";
+       "UDP header matching supported.";
    }
    
-   feature icmp-acl {
+   feature icmp-fields {
      description
-       "ICMP header ACL supported.";
+       "ICMP header matching supported.";
    }
    
    feature any-acl {
@@ -275,14 +281,6 @@ module ietf-access-control-list {
                matched upon before any action is taken on them. 
                The rules are selected based on the feature set 
                defined by the server and the acl-type defined.";
-            
-            container l2-acl {
-              if-feature l2-acl;
-              must "../../../../acl-type = 'eth-acl'";
-              uses packet-fields:acl-eth-header-fields;
-              description
-                "Rule set for L2 ACL.";
-            }
 
             container ipv4-acl {
               if-feature ipv4-acl;
@@ -302,56 +300,74 @@ module ietf-access-control-list {
                 "Rule set that supports IPv6 headers.";
             }
 
-            container l2-l3-ipv4-acl {
-              if-feature mixed-ipv4-acl;
-              must "../../../../acl-type = 'mixed-l2-l3-ipv4-acl'";
+            container ipv46-acl {
+              if-feature ipv46-acl;
+              must "../../../../acl-type = 'ipv46-acl'";
+              uses packet-fields:acl-ip-header-fields;
+              uses packet-fields:acl-ipv4-header-fields;
+              uses packet-fields:acl-ipv6-header-fields;
+              description
+                "Rule set that is a logical OR (||) of IPv4 and IPv6 headers.";
+            }
+            
+            container eth-acl {
+              if-feature eth-acl;
+              must "../../../../acl-type = 'eth-acl'";
+              uses packet-fields:acl-eth-header-fields;
+              description
+                "Rule set for L2 Ethernet ACL.";
+            }
+
+            container eth-ipv4-acl {
+              if-feature eth-ipv4-acl;
+              must "../../../../acl-type = 'eth-ipv4-acl'";
               uses packet-fields:acl-eth-header-fields;
 	          uses packet-fields:acl-ip-header-fields;
 	          uses packet-fields:acl-ipv4-header-fields;
               description
-                "Rule set that is a logical AND (&&) of l2 
-                 and ipv4 headers.";
+                "Rule set that is a logical AND (&&) of L2 Ethernet and
+                 IPv4 headers.";
             }
 
-            container l2-l3-ipv6-acl {
-              if-feature mixed-ipv6-acl;
-              must "../../../../acl-type = 'mixed-l2-l3-ipv6-acl'";
+            container eth-ipv6-acl {
+              if-feature eth-ipv6-acl;
+              must "../../../../acl-type = 'eth-ipv6-acl'";
               uses packet-fields:acl-eth-header-fields;
               uses packet-fields:acl-ip-header-fields;
               uses packet-fields:acl-ipv6-header-fields;
               description
-                "Rule set that is a logical AND (&&) of L2 
-                 && IPv6 headers.";
+                "Rule set that is a logical AND (&&) of L2 Ethernet &&
+                IPv6 headers.";
             }
 
-            container l2-l3-ipv4-ipv6-acl {
-              if-feature l2-l3-ipv4-ipv6-acl;
-              must "../../../../acl-type = 'mixed-l2-l3-ipv4-ipv6-acl'";
+            container eth-ipv46-acl {
+              if-feature eth-ipv46-acl;
+              must "../../../../acl-type = 'eth-ipv46-acl'";
               uses packet-fields:acl-eth-header-fields;
               uses packet-fields:acl-ip-header-fields;
               uses packet-fields:acl-ipv4-header-fields;
               uses packet-fields:acl-ipv6-header-fields;
               description
-                "Rule set that is a logical AND (&&) of L2 
-                 && IPv4 && IPv6 headers.";
+                "Rule set that is a logical AND (&&) of L2 Ethernet &&
+                 (IPv4 || IPv6) headers.";
             }
             
-            container tcp-acl {
-              if-feature tcp-acl;
+            container tcp-fields {
+              if-feature tcp-fields;
               uses packet-fields:acl-tcp-header-fields;
               description
                 "Rule set that defines TCP headers.";
             }
             
-            container udp-acl {
-              if-feature udp-acl;
+            container udp-fields {
+              if-feature udp-fields;
               uses packet-fields:acl-udp-header-fields;
               description
                 "Rule set that defines UDP headers.";
             }
             
-            container icmp-acl {
-              if-feature icmp-acl;
+            container icmp-fields {
+              if-feature icmp-fields;
               uses packet-fields:acl-icmp-header-fields;
               description
                 "Rule set that defines ICMP headers.";


### PR DESCRIPTION
The old naming mixed apples and oranges with names like l2-ipv4-acl.
IPv4 is an instance of a L3 technology, so keeping to oranges the
correct name is eth-ipv4-acl, which is precisely what I've renamed
things to.

I've removed "mixed" as I find it superfluous. I've also added in a new
type called eth-ipv46.

Descriptions are updated, I think it's an improvement in wording but it
could possible taking further improvements :)

I renamed tcp/udp/icmp-acl to -fields instead as they are not separate
ACL types but rather support for matching certain header fields.

Should icmp-fields be split into ICMPv4 and ICMPv6? They are different
after all..