### PR TITLE
Fix indent, line breaks & whitespace

### DIFF
--- a/src/yang/example-acl-configuration.xml
+++ b/src/yang/example-acl-configuration.xml
@@ -1,29 +1,28 @@
 <?xml version='1.0' encoding='UTF-8'?>
-  <data xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
-    <access-lists xmlns="urn:ietf:params:xml:ns:yang:
-     ietf-access-control-list">
-      <acl>
-        <acl-name>sample-ipv4-acl</acl-name>
-        <acl-type>ipv4-acl</acl-type>
-        <aces>
-          <ace>
-            <rule-name>rule1</rule-name>
-            <matches>
-              <ipv4-acl>
-                <protocol>tcp</protocol>
-                <destination-ipv4-network>
-                  11.11.11.1/24
-                </destination-ipv4-network>
-                <source-ipv4-network>
-                  10.10.10.1/24
-                </source-ipv4-network>
-              </ipv4-acl>
-            </matches>
-            <actions>
-              <packet-handling>deny</packet-handling>
-            </actions>
-          </ace>
-        </aces>
-      </acl>
-    </access-lists>
-  </data>  
+<data xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <access-lists xmlns="urn:ietf:params:xml:ns:yang:ietf-access-control-list">
+    <acl>
+      <acl-name>sample-ipv4-acl</acl-name>
+      <acl-type>ipv4-acl</acl-type>
+      <aces>
+        <ace>
+          <rule-name>rule1</rule-name>
+          <matches>
+            <ipv4-acl>
+              <protocol>tcp</protocol>
+              <destination-ipv4-network>
+                11.11.11.1/24
+              </destination-ipv4-network>
+              <source-ipv4-network>
+                10.10.10.1/24
+              </source-ipv4-network>
+            </ipv4-acl>
+          </matches>
+          <actions>
+            <packet-handling>deny</packet-handling>
+          </actions>
+        </ace>
+      </aces>
+    </acl>
+  </access-lists>
+</data>

--- a/src/yang/example-ext-route-filter.yang
+++ b/src/yang/example-ext-route-filter.yang
@@ -1,7 +1,7 @@
 module example-ext-route-filter {
   namespace "urn:ietf:params:xml:ns:yang:example-ext-route-filter";
   prefix example-ext-route-filter;
-  
+
   import ietf-inet-types {
     prefix "inet";
   }
@@ -29,13 +29,13 @@ module example-ext-route-filter {
       ietf-access-control-list model";
     reference "Example route filter";
   }
-  
+
   augment "/ietf-acl:access-lists/ietf-acl:acl/" +
           "ietf-acl:aces/ietf-acl:ace/ietf-acl:matches" {
     description "
       This module augments the matches container in the ietf-acl
       module with route filter specific actions";
-    
+
     choice route-prefix{
       description "Define route filter match criteria";
       case range {

--- a/src/yang/example-newco-acl.yang
+++ b/src/yang/example-newco-acl.yang
@@ -21,7 +21,7 @@ module example-newco-acl {
   revision YYYY-MM-DD {
     description
       "Creating NewCo proprietary extensions to ietf-acl model";
-    
+
     reference
       "RFC XXXX: Network Access Control List (ACL)
        YANG Data  Model";

--- a/src/yang/ietf-access-control-list.yang
+++ b/src/yang/ietf-access-control-list.yang
@@ -2,23 +2,23 @@ module ietf-access-control-list {
   yang-version 1.1;
   namespace "urn:ietf:params:xml:ns:yang:ietf-access-control-list";
   prefix acl;
-  
+
   import ietf-yang-types {
     prefix yang;
   }
-  
+
   import ietf-packet-fields {
     prefix packet-fields;
   }
-  
+
   import ietf-interfaces {
     prefix if;
   }
-  
-  organization 
+
+  organization
     "IETF NETMOD (NETCONF Data Modeling Language)
      Working Group";
-  
+
   contact
     "WG Web: http://tools.ietf.org/wg/netmod/
      WG List: netmod@ietf.org
@@ -31,11 +31,11 @@ module ietf-access-control-list {
              sagarwal12@cisco.com
      Editor: Dana Blair
              dblair@cisco.com";
-  
+
   description
     "This YANG module defines a component that describe the
      configuration of Access Control Lists (ACLs).
-	  
+
      Copyright (c) 2017 IETF Trust and the persons identified as
      the document authors.  All rights reserved.
      Redistribution and use in source and binary forms, with or
@@ -44,10 +44,10 @@ module ietf-access-control-list {
      License set forth in Section 4.c of the IETF Trust's Legal
      Provisions Relating to IETF Documents
      (http://trustee.ietf.org/license-info).
-	  
+
      This version of this YANG module is part of RFC XXXX; see
      the RFC itself for full legal notices.";
-  
+
   revision YYYY-MM-DD {
     description
       "Added feature and identity statements for different types
@@ -57,7 +57,7 @@ module ietf-access-control-list {
     reference
       "RFC XXX: Network Access Control List (ACL) YANG Data Model.";
   }
-  
+
   /*
    * Identities
    */
@@ -143,8 +143,8 @@ module ietf-access-control-list {
 
   identity mixed-l2-l3-ipv4-acl {
     base "acl:acl-base";
-     
-    description 
+
+    description
       "ACL that contains a mix of entries that
        primarily match on fields in ethernet headers,
        entries that primarily match on IPv4 headers.
@@ -154,8 +154,8 @@ module ietf-access-control-list {
 
   identity mixed-l2-l3-ipv6-acl {
     base "acl:acl-base";
-     
-    description 
+
+    description
       "ACL that contains a mix of entries that
        primarily match on fields in ethernet headers, entries
        that primarily match on fields in IPv6 headers. Matching on
@@ -164,18 +164,18 @@ module ietf-access-control-list {
 
   identity mixed-l2-l3-ipv4-ipv6-acl {
     base "acl:acl-base";
-     
-    description 
+
+    description
       "ACL that contains a mix of entries that
        primarily match on fields in ethernet headers, entries
        that primarily match on fields in IPv4 headers, and entries
        that primarily match on fields in IPv6 headers. Matching on
        layer 4 header fields may also exist in the list.";
   }
-  
+
   identity any-acl {
     base "acl:acl-base";
-	  
+
     description
       "ACL that can contain any pattern to match upon";
   }
@@ -189,48 +189,48 @@ module ietf-access-control-list {
   }
 
   feature ipv4-acl {
-    description 
+    description
       "Layer 3 IPv4 ACL supported";
   }
-	
+
   feature ipv6-acl {
     description
       "Layer 3 IPv6 ACL supported";
   }
-	
+
   feature mixed-ipv4-acl {
     description
       "Layer 2 and Layer 3 IPv4 ACL supported";
   }
-	
+
   feature mixed-ipv6-acl {
     description
       "Layer 2 and Layer 3 IPv6 ACL supported";
   }
-	
+
   feature l2-l3-ipv4-ipv6-acl {
     description
       "Layer 2 and any Layer 3 ACL supported.";
   }
-   
+
   feature tcp-acl {
     description
       "TCP header ACL supported.";
   }
-   
+
   feature udp-acl {
     description
       "UDP header ACL supported.";
   }
-   
+
   feature icmp-acl {
     description
       "ICMP header ACL supported.";
   }
-   
+
   feature any-acl {
     description
-     "ACL for any pattern.";
+      "ACL for any pattern.";
   }
 
   /*
@@ -240,13 +240,13 @@ module ietf-access-control-list {
     description
       "ACL counters are available and reported only per interface";
   }
-   
+
   feature acl-aggregate-stats {
     description
       "ACL counters are aggregated over all interfaces, and reported
        only per ACL entry";
   }
-   
+
   feature interface-acl-aggregate {
     description
       "ACL counters are reported per interface, and also aggregated
@@ -277,12 +277,12 @@ module ietf-access-control-list {
   grouping interface-acl {
     description
       "Grouping for per-interface ingress ACL data";
-    
+
     container acl-sets {
       description
         "Enclosing container the list of ingress ACLs on the
          interface";
- 
+
       list acl-set {
         key "set-name type";
         ordered-by user;
@@ -399,7 +399,7 @@ module ietf-access-control-list {
         type acl-type;
         description
           "Type of access control list. Indicates the primary intended
-           type of match criteria (e.g. ethernet, IPv4, IPv6, mixed, 
+           type of match criteria (e.g. ethernet, IPv4, IPv6, mixed,
            etc) used in the list instance.";
       }
       container aces {
@@ -422,11 +422,11 @@ module ietf-access-control-list {
 
           container matches {
             description
-              "The rules in this set determine what fields will be 
-               matched upon before any action is taken on them. 
-               The rules are selected based on the feature set 
+              "The rules in this set determine what fields will be
+               matched upon before any action is taken on them.
+               The rules are selected based on the feature set
                defined by the server and the acl-type defined.";
-            
+
             container l2-acl {
               if-feature l2-acl;
               must "derived-from(../../../../acl-type, 'acl:eth-acl')";
@@ -437,10 +437,10 @@ module ietf-access-control-list {
 
             container ipv4-acl {
               if-feature ipv4-acl;
-	            must "derived-from(../../../../acl-type, " +
-            	   "'acl:ipv4-acl')";
+              must "derived-from(../../../../acl-type, " +
+                "'acl:ipv4-acl')";
               uses packet-fields:acl-ip-header-fields;
-	            uses packet-fields:acl-ipv4-header-fields;
+              uses packet-fields:acl-ipv4-header-fields;
               description
                 "Rule set that supports IPv4 headers.";
             }
@@ -448,7 +448,7 @@ module ietf-access-control-list {
             container ipv6-acl {
               if-feature ipv6-acl;
               must "derived-from(../../../../acl-type, " +
-                   "'acl:ipv6-acl')";
+                "'acl:ipv6-acl')";
               uses packet-fields:acl-ip-header-fields;
               uses packet-fields:acl-ipv6-header-fields;
               description
@@ -458,61 +458,61 @@ module ietf-access-control-list {
             container l2-l3-ipv4-acl {
               if-feature mixed-ipv4-acl;
               must "derived-from(../../../../acl-type, " +
-                   "'acl:mixed-l2-l3-ipv4-acl')";
+                "'acl:mixed-l2-l3-ipv4-acl')";
               uses packet-fields:acl-eth-header-fields;
               uses packet-fields:acl-ip-header-fields;
               uses packet-fields:acl-ipv4-header-fields;
               description
-                "Rule set that is a logical AND (&&) of l2 
+                "Rule set that is a logical AND (&&) of l2
                  and ipv4 headers.";
             }
 
             container l2-l3-ipv6-acl {
               if-feature mixed-ipv6-acl;
               must "derived-from(../../../../acl-type, " +
-                   "'acl:mixed-l2-l3-ipv6-acl')";
+                "'acl:mixed-l2-l3-ipv6-acl')";
               uses packet-fields:acl-eth-header-fields;
               uses packet-fields:acl-ip-header-fields;
               uses packet-fields:acl-ipv6-header-fields;
               description
-                "Rule set that is a logical AND (&&) of L2 
+                "Rule set that is a logical AND (&&) of L2
                  && IPv6 headers.";
             }
 
             container l2-l3-ipv4-ipv6-acl {
               if-feature l2-l3-ipv4-ipv6-acl;
               must "derived-from(../../../../acl-type, " +
-                   "'acl:mixed-l2-l3-ipv4-ipv6-acl')";
+                "'acl:mixed-l2-l3-ipv4-ipv6-acl')";
               uses packet-fields:acl-eth-header-fields;
               uses packet-fields:acl-ip-header-fields;
               uses packet-fields:acl-ipv4-header-fields;
               uses packet-fields:acl-ipv6-header-fields;
               description
-                "Rule set that is a logical AND (&&) of L2 
+                "Rule set that is a logical AND (&&) of L2
                  && IPv4 && IPv6 headers.";
             }
-            
+
             container tcp-acl {
               if-feature tcp-acl;
               uses packet-fields:acl-tcp-header-fields;
               description
                 "Rule set that defines TCP headers.";
             }
-            
+
             container udp-acl {
               if-feature udp-acl;
               uses packet-fields:acl-udp-header-fields;
               description
                 "Rule set that defines UDP headers.";
             }
-            
+
             container icmp-acl {
               if-feature icmp-acl;
               uses packet-fields:acl-icmp-header-fields;
               description
                 "Rule set that defines ICMP headers.";
             }
-             
+
             container any-acl {
               if-feature any-acl;
               must "derived-from(../../../../acl-type, 'acl:any-acl')";
@@ -520,7 +520,7 @@ module ietf-access-control-list {
               description
                 "Rule set that allows for a any ACL.";
             }
-            
+
             leaf interface {
               type if:interface-ref;
               description
@@ -533,34 +533,34 @@ module ietf-access-control-list {
             if-feature "acl-aggregate-stats or interface-acl-aggregate";
             description
               "Definitions of action criteria for this ace entry";
-                leaf forwarding {
-                  type identityref {
-                    base forwarding-action;
-                  }
-                  mandatory true;
-                  description
-                    "Specifies the forwarding action per ace entry";
-                }
+            leaf forwarding {
+              type identityref {
+                base forwarding-action;
+              }
+              mandatory true;
+              description
+                "Specifies the forwarding action per ace entry";
+            }
 
-                leaf logging {
-                  type identityref {
-                    base log-action;
-                  }
-                  default log-none;
-                  description
-                  "Specifies the log action and destination for
+            leaf logging {
+              type identityref {
+                base log-action;
+              }
+              default log-none;
+              description
+                "Specifies the log action and destination for
                    matched packets. Default value is not to log the
                    packet.";
-                }
+            }
 
-                leaf icmp-off {
-                  type boolean;
-                  default "false";
-                  description
-                  "true indicates ICMP errors will never be generated
+            leaf icmp-off {
+              type boolean;
+              default "false";
+              description
+                "true indicates ICMP errors will never be generated
                    in response to an ICMP error message. false indicates
                    ICMP error will be generated.";
-                }
+            }
           }
           uses acl-counters;
         }
@@ -573,8 +573,8 @@ module ietf-access-control-list {
 
       list interface {
         key "interface-id";
-          description
-            "List of interfaces on which ACLs are set";
+        description
+          "List of interfaces on which ACLs are set";
 
         leaf interface-id {
           type if:interface-ref;

--- a/src/yang/ietf-packet-fields.yang
+++ b/src/yang/ietf-packet-fields.yang
@@ -1,23 +1,23 @@
 module ietf-packet-fields {
   namespace "urn:ietf:params:xml:ns:yang:ietf-packet-fields";
   prefix packet-fields;
-  
+
   import ietf-inet-types {
     prefix inet;
   }
-  
+
   import ietf-yang-types {
     prefix yang;
   }
-  
+
   import ietf-ethertypes {
     prefix eth;
   }
 
-  organization 
+  organization
     "IETF NETMOD (NETCONF Data Modeling Language) Working
      Group";
-  
+
   contact
     "WG Web: http://tools.ietf.org/wg/netmod/
      WG List: netmod@ietf.org
@@ -47,14 +47,14 @@ module ietf-packet-fields {
     (http://trustee.ietf.org/license-info).
     This version of this YANG module is part of RFC XXXX; see
     the RFC itself for full legal notices.";
-  
+
   revision YYYY-MM-DD {
     description
       "Added header fields for TCP, UDP, and ICMP.";
     reference
       "RFC XXX: Network Access Control List (ACL) YANG Data Model.";
   }
-  
+
   /*
    * Typedefs
    */
@@ -84,7 +84,7 @@ module ietf-packet-fields {
        and upper-port is not specified. The operator
        therefore further qualifies lower-port only.";
   }
-  
+
   grouping acl-transport-header-fields {
     description
       "Transport header fields";
@@ -92,14 +92,14 @@ module ietf-packet-fields {
       presence "Enables setting source port range";
       description
         "Inclusive range representing source ports to be used.
-    	 When only lower-port is present, it represents a single 
+         When only lower-port is present, it represents a single
          port and eq operator is assumed to be default.
-          
+
          When both lower-port and upper-port are specified,
          it implies a range inclusive of both values.
 
          If no port is specified, 'any' (wildcard) is assumed.";
-      
+
       leaf lower-port {
         type inet:port-number;
         mandatory true;
@@ -110,7 +110,7 @@ module ietf-packet-fields {
         type inet:port-number;
         must ". >= ../lower-port" {
           error-message
-          "The upper-port must be greater than or equal 
+          "The upper-port must be greater than or equal
            to lower-port";
         }
         description
@@ -132,19 +132,19 @@ module ietf-packet-fields {
           "Operator to be applied on the lower-port.";
       }
     }
-    
+
     container destination-port-range {
       presence "Enables setting destination port range";
       description
-        "Inclusive range representing destination ports to be used. 
-         When only lower-port is present, it represents a single 
+        "Inclusive range representing destination ports to be used.
+         When only lower-port is present, it represents a single
          port and eq operator is assumed to be default.
-         
+
          When both lower-port and upper-port are specified,
          it implies a range inclusive of both values.
-    
+
          If no port is specified, 'any' (wildcard) is assumed. ";
-      
+
       leaf lower-port {
         type inet:port-number;
         mandatory true;
@@ -155,7 +155,7 @@ module ietf-packet-fields {
         type inet:port-number;
         must ". >= ../lower-port" {
           error-message
-            "The upper-port must be greater than or equal 
+            "The upper-port must be greater than or equal
              to lower-port";
         }
         description
@@ -178,13 +178,13 @@ module ietf-packet-fields {
       }
     }
   }
-  
+
   grouping acl-ip-header-fields {
     description
       "IP header fields common to ipv4 and ipv6";
     reference
       "RFC 791.";
-    
+
     leaf dscp {
       type inet:dscp;
       description
@@ -193,7 +193,7 @@ module ietf-packet-fields {
         "RFC 2474: Definition of Differentiated services field
          (DS field) in the IPv4 and IPv6 headers.";
     }
-    
+
     leaf ecn {
       type uint8 {
         range 0..3;
@@ -203,16 +203,16 @@ module ietf-packet-fields {
       reference
         "RFC 3168.";
     }
-    
+
     leaf length {
       type uint16;
       description
         "In IPv4 header field, this field is known as the Total Length.
          Total Length is the length of the datagram, measured in octets,
          including internet header and data.
-    	  
-         In IPv6 header field, this field is known as the Payload 
-         Length, the length of the IPv6 payload, i.e. the rest of 
+
+         In IPv6 header field, this field is known as the Payload
+         Length, the length of the IPv6 payload, i.e. the rest of
          the packet following the IPv6 header, in octets.";
       reference
         "RFC 719, RFC 2460";
@@ -221,14 +221,14 @@ module ietf-packet-fields {
     leaf ttl {
       type uint8;
       description
-        "This field indicates the maximum time the datagram is allowed 
-         to remain in the internet system.  If this field contains the 
+        "This field indicates the maximum time the datagram is allowed
+         to remain in the internet system.  If this field contains the
          value zero, then the datagram must be destroyed.
-    	  
+
          In IPv6, this field is known as the Hop Limit.";
       reference "RFC 719, RFC 2460";
     }
-    
+
     leaf protocol {
       type uint8;
       description
@@ -236,22 +236,22 @@ module ietf-packet-fields {
     }
     uses acl-transport-header-fields;
   }
-  
+
   grouping acl-ipv4-header-fields {
     description
       "Fields in IPv4 header.";
-    
+
     leaf ihl {
       type uint8 {
         range "5..60";
       }
       description
-        "An IPv4 header field, the Internet Header Length (IHL) is 
-    	 the length of the internet header in 32 bit words, and 
-         thus points to the beginning of the data. Note that the 
+        "An IPv4 header field, the Internet Header Length (IHL) is
+         the length of the internet header in 32 bit words, and
+         thus points to the beginning of the data. Note that the
          minimum value for a correct header is 5.";
     }
-    
+
     leaf flags {
       type bits {
         bit reserved {
@@ -269,30 +269,30 @@ module ietf-packet-fields {
           position 2;
           description
             "Setting the value to 0 indicates this is the last fragment,
-             and setting the value to 1 indicates more fragments are 
+             and setting the value to 1 indicates more fragments are
              coming.";
         }
       }
       description
         "Bit definitions for the flags field in IPv4 header.";
     }
-    
+
     leaf offset {
       type uint16 {
         range "20..65535";
       }
       description
-        "The fragment offset is measured in units of 8 octets (64 bits).  
+        "The fragment offset is measured in units of 8 octets (64 bits).
          The first fragment has offset zero. The length is 13 bits";
     }
-    
+
     leaf identification {
       type uint16;
       description
-        "An identifying value assigned by the sender to aid in 
+        "An identifying value assigned by the sender to aid in
          assembling the fragments of a datagram.";
     }
-    
+
     leaf destination-ipv4-network {
       type inet:ipv4-prefix;
       description
@@ -304,33 +304,33 @@ module ietf-packet-fields {
         "Source IPv4 address prefix.";
     }
   }
-  
+
   grouping acl-ipv6-header-fields {
     description
       "Fields in IPv6 header";
-    
+
     leaf next-header {
       type uint8;
       description
-        "Identifies the type of header immediately following the 
-         IPv6 header. Uses the same values as the IPv4 Protocol 
+        "Identifies the type of header immediately following the
+         IPv6 header. Uses the same values as the IPv4 Protocol
          field.";
       reference
         "RFC 2460";
     }
-    
+
     leaf destination-ipv6-network {
       type inet:ipv6-prefix;
       description
         "Destination IPv6 address prefix.";
     }
-    
+
     leaf source-ipv6-network {
       type inet:ipv6-prefix;
       description
         "Source IPv6 address prefix.";
     }
-    
+
     leaf flow-label {
       type inet:ipv6-flow-label;
       description
@@ -339,14 +339,14 @@ module ietf-packet-fields {
     reference
       "RFC 4291: IP Version 6 Addressing Architecture
        RFC 4007: IPv6 Scoped Address Architecture
-       RFC 5952: A Recommendation for IPv6 Address Text 
+       RFC 5952: A Recommendation for IPv6 Address Text
                  Representation";
   }
-  
+
   grouping acl-eth-header-fields {
     description
       "Fields in Ethernet header.";
-    
+
     leaf destination-mac-address {
       type yang:mac-address;
       description
@@ -371,20 +371,20 @@ module ietf-packet-fields {
       type eth:ethertype;
       description
         "The Ethernet Type (or Length) value represented
-         in the canonical order defined by IEEE 802. 
-         The canonical representation uses lowercase 
+         in the canonical order defined by IEEE 802.
+         The canonical representation uses lowercase
          characters.";
       reference
         "IEEE 802-2014 Clause 9.2";
     }
     reference
-      "IEEE 802: IEEE Standard for Local and Metropolitan 
+      "IEEE 802: IEEE Standard for Local and Metropolitan
        Area Networks: Overview and Architecture.";
   }
-  
+
   grouping acl-tcp-header-fields {
     description
-      "Collection of TCP header fields that can be used to 
+      "Collection of TCP header fields that can be used to
        setup a match filter.";
 
     leaf sequence-number {
@@ -392,33 +392,33 @@ module ietf-packet-fields {
       description
         "Sequence number that appears in the packet.";
     }
-	
+
     leaf acknowledgement-number {
       type uint32;
       description
-        "The acknowledgement number that appears in the 
+        "The acknowledgement number that appears in the
          packet.";
     }
-	
+
     leaf data-offset {
       type uint8 {
         range "5..15";
       }
       description
-        "Specifies the size of the TCP header in 32-bit 
-         words. The minimum size header is 5 words and 
-         the maximum is 15 words thus giving the minimum 
-         size of 20 bytes and maximum of 60 bytes, 
-         allowing for up to 40 bytes of options in the 
+        "Specifies the size of the TCP header in 32-bit
+         words. The minimum size header is 5 words and
+         the maximum is 15 words thus giving the minimum
+         size of 20 bytes and maximum of 60 bytes,
+         allowing for up to 40 bytes of options in the
          header.";
     }
-	
+
     leaf reserved {
       type uint8;
       description
         "Reserved for future use.";
     }
-	
+
     leaf flags {
       type bits {
         bit ns {
@@ -430,23 +430,23 @@ module ietf-packet-fields {
         bit cwr {
           position 1;
           description
-            "Congestion Window Reduced (CWR) flag is set by 
-             the sending host to indicate that it received 
-             a TCP segment with the ECE flag set and had 
+            "Congestion Window Reduced (CWR) flag is set by
+             the sending host to indicate that it received
+             a TCP segment with the ECE flag set and had
              responded in congestion control mechanism.";
           reference "RFC 3168";
         }
         bit ece {
           position 2;
           description
-            "ECN-Echo has a dual role, depending on the value 
+            "ECN-Echo has a dual role, depending on the value
              of the SYN flag. It indicates:
-             If the SYN flag is set (1), that the TCP peer is ECN 
-             capable. If the SYN flag is clear (0), that a packet 
-             with Congestion Experienced flag set (ECN=11) in IP 
-             header was received during normal transmission 
-             (added to header by RFC 3168). This serves as an 
-             indication of network congestion (or impending 
+             If the SYN flag is set (1), that the TCP peer is ECN
+             capable. If the SYN flag is clear (0), that a packet
+             with Congestion Experienced flag set (ECN=11) in IP
+             header was received during normal transmission
+             (added to header by RFC 3168). This serves as an
+             indication of network congestion (or impending
              congestion) to the TCP sender.";
         }
         bit urg {
@@ -457,14 +457,14 @@ module ietf-packet-fields {
         bit ack {
           position 4;
           description
-            "Indicates that the Acknowledgment field is significant. 
-             All packets after the initial SYN packet sent by the 
+            "Indicates that the Acknowledgment field is significant.
+             All packets after the initial SYN packet sent by the
              client should have this flag set.";
         }
         bit psh {
           position 5;
           description
-            "Push function. Asks to push the buffered data to the 
+            "Push function. Asks to push the buffered data to the
              receiving application.";
         }
         bit rst {
@@ -475,10 +475,10 @@ module ietf-packet-fields {
         bit syn {
           position 7;
           description
-            "Synchronize sequence numbers. Only the first packet 
-             sent from each end should have this flag set. Some 
-             other flags and fields change meaning based on this 
-             flag, and some are only valid for when it is set, 
+            "Synchronize sequence numbers. Only the first packet
+             sent from each end should have this flag set. Some
+             other flags and fields change meaning based on this
+             flag, and some are only valid for when it is set,
              and others when it is clear.";
         }
         bit fin {
@@ -490,91 +490,91 @@ module ietf-packet-fields {
       description
         "Also known as Control Bits. Contains 9 1-bit flags.";
     }
-	
+
     leaf window-size {
       type uint16;
       description
-        "The size of the receive window, which specifies 
-         the number of window size units (by default, 
-         bytes) (beyond the segment identified by the 
-         sequence number in the acknowledgment field) 
-         that the sender of this segment is currently 
+        "The size of the receive window, which specifies
+         the number of window size units (by default,
+         bytes) (beyond the segment identified by the
+         sequence number in the acknowledgment field)
+         that the sender of this segment is currently
          willing to receive.";
     }
-	
+
     leaf urgent-pointer {
       type uint16;
       description
         "This field is an offset from the sequence number
          indicating the last urgent data byte.";
     }
-	
+
     leaf options {
       type uint32;
       description
-        "The length of this field is determined by the 
-         data offset field. Options have up to three 
-         fields: Option-Kind (1 byte), Option-Length 
-         (1 byte), Option-Data (variable). The Option-Kind 
-         field indicates the type of option, and is the 
-         only field that is not optional. Depending on 
-         what kind of option we are dealing with, 
-         the next two fields may be set: the Option-Length 
-         field indicates the total length of the option, 
-         and the Option-Data field contains the value of 
+        "The length of this field is determined by the
+         data offset field. Options have up to three
+         fields: Option-Kind (1 byte), Option-Length
+         (1 byte), Option-Data (variable). The Option-Kind
+         field indicates the type of option, and is the
+         only field that is not optional. Depending on
+         what kind of option we are dealing with,
+         the next two fields may be set: the Option-Length
+         field indicates the total length of the option,
+         and the Option-Data field contains the value of
          the option, if applicable.";
     }
   }
-  
+
   grouping acl-udp-header-fields {
     description
-      "Collection of UDP header fields that can be used 
+      "Collection of UDP header fields that can be used
        to setup a match filter.";
-    
+
     leaf length {
       type uint16;
       description
-        "A field that specifies the length in bytes of 
-         the UDP header and UDP data. The minimum 
-         length is 8 bytes because that is the length of 
-         the header. The field size sets a theoretical 
-         limit of 65,535 bytes (8 byte header + 65,527 
-         bytes of data) for a UDP datagram. However the 
-         actual limit for the data length, which is 
-         imposed by the underlying IPv4 protocol, is 
-         65,507 bytes (65,535 minus 8 byte UDP header 
+        "A field that specifies the length in bytes of
+         the UDP header and UDP data. The minimum
+         length is 8 bytes because that is the length of
+         the header. The field size sets a theoretical
+         limit of 65,535 bytes (8 byte header + 65,527
+         bytes of data) for a UDP datagram. However the
+         actual limit for the data length, which is
+         imposed by the underlying IPv4 protocol, is
+         65,507 bytes (65,535 minus 8 byte UDP header
          minus 20 byte IP header).
-         
-         In IPv6 jumbograms it is possible to have 
-         UDP packets of size greater than 65,535 bytes. 
-         RFC 2675 specifies that the length field is set 
-         to zero if the length of the UDP header plus 
+
+         In IPv6 jumbograms it is possible to have
+         UDP packets of size greater than 65,535 bytes.
+         RFC 2675 specifies that the length field is set
+         to zero if the length of the UDP header plus
          UDP data is greater than 65,535.";
-    }    
+    }
   }
-  
+
   grouping acl-icmp-header-fields {
     description
-      "Collection of ICMP header fields that can be 
+      "Collection of ICMP header fields that can be
        used to setup a match filter.";
-    
+
     leaf type {
       type uint8;
       description
         "Also known as Control messages.";
       reference "RFC 792";
     }
-    
+
     leaf code {
       type uint8;
       description
         "ICMP subtype. Also known as Control messages.";
     }
-    
+
     leaf rest-of-header {
       type uint32;
       description
-        "Four-bytes field, contents vary based on the 
+        "Four-bytes field, contents vary based on the
          ICMP type and code.";
     }
   }


### PR DESCRIPTION
This is just a very simple fix of whitespace by consistently using space and not tabs. White space (space and tab) at end of lines are removed. A line break in the XML example has been removed since it was in the wrong place (line breaking the namespace is probably a bad idea".

My other patches will be based on this one so by merging this first (which should really be a no-brainer) the diff output of upcoming patches will look much better.